### PR TITLE
chore: Add more information to the readme on how to override the values

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ What changes are proposed in this pull request?
 
 How was this change tested?
 (Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests, right now, the best way to 
-test is using minikube on your local, the following steps help you execute a test on local)
+test is using the kube environemnt available to you, the following steps help you execute a test with default values)
 - [ ] Manually deployed and tested with default values.yml
 `kubectl config use-context docker-for-desktop`
 `helm init`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ What changes are proposed in this pull request?
 
 How was this change tested?
 (Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests, right now, the best way to 
-test is using the kube environemnt available to you, the following steps help you execute a test with default values)
+test is using the kube environment available to you, the following steps help you execute a test with default values in  a docker-for-desktop environment)
 - [ ] Manually deployed and tested with default values.yml
 `kubectl config use-context docker-for-desktop`
 `helm init`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,5 +5,11 @@ What changes are proposed in this pull request?
 
 How was this change tested?
 (Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
-- 
-- 
+- [] Manually deployed and tested with default values.yml
+`kubectl config use-context docker-for-desktop`
+`helm init`
+`helm install .`
+Output:
+```
+
+```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,8 @@ What changes are proposed in this pull request?
 - 
 
 How was this change tested?
-(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
+(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests, right now, the best way to 
+test is using minikube on your local, the following steps help you execute a test on local)
 - [ ] Manually deployed and tested with default values.yml
 `kubectl config use-context docker-for-desktop`
 `helm init`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ What changes are proposed in this pull request?
 
 How was this change tested?
 (Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
-- [] Manually deployed and tested with default values.yml
+- [ ] Manually deployed and tested with default values.yml
 `kubectl config use-context docker-for-desktop`
 `helm init`
 `helm install .`

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # chart-hyperopt
 © Hipages Group Pty Ltd 2019
 
-Helm Chart to deploy [hyperopt](https://github.com/hyperopt/hyperopt): a Distributed Asynchronous Hyperparameter Optimization in Python
-This complements the [hyperkops](https://github.com/hipagesgroup/hyperkops) repository which enables the deployment of hyperopt in Kubernetes. 
+Helm Chart to deploy [hyperopt](https://github.com/hyperopt/hyperopt): a Distributed Asynchronous Hyperparameter 
+Optimization in Python.
+This repository uses the docker images published from [hyperkops](https://github.com/hipagesgroup/hyperkops) repository 
+and provides a helm chart for deployment on Kubernetes. 
 
 ## TL;DR;
 
@@ -23,7 +25,7 @@ This chart bootstraps a [Hyperopt](https://github.com/hyperopt/hyperopt) deploym
 First clone the repository using git clone:
 
 ```bash
-git clone https://github.com/hyperopt/hyperopt.git
+git clone https://github.com/hipagesgroup/chart-hyperopt.git
 ```
 
 To install the chart with the release name `my-release`:
@@ -38,7 +40,31 @@ section lists the parameters that can be configured during installation.
 > **Tip**: List all releases using `helm list`
 
 The helm chart outputs some useful information at the time of installation, like the portforward command required to 
-connect to mongo db.
+connect to mongo db. This can be seen in the NOTES section of the output, eg.:
+```
+$ helm install .   
+
+NAME:   silly-newt
+LAST DEPLOYED: Tue Jun 25 10:50:15 2019
+NAMESPACE: default
+STATUS: DEPLOYED
+...
+...
+...
+
+NOTES:
+1. To connect mongo db using your local to deploy hyperopt job
+
+export POD_NAME=$(kubectl get pods --namespace default -l "app.kubernetes.io/name=chart-hyperopt-mongo,app.kubernetes.io/instance=silly-newt" -o jsonpath="{.items[0].metadata.name}")
+
+kubectl port-forward $POD_NAME 27017:27017
+
+You can then connect to mongo db at:
+localhost:27017
+
+2. you can connect to the mongo db on other deployments within the kubernetes environment using this service url:
+"silly-newt-chart-hyperopt-mongo.default.svc.cluster.local"
+```
 
 ## Uninstalling the Chart
 
@@ -57,5 +83,63 @@ A YAML file that specifies the values for the parameters can be provided while i
 $ helm install --name my-release -f values.yaml .
 ```
 
-> **Tip**: You can use the default [values.yaml](values.yaml)
+> **Tip**: You can use the default [values.yaml](values.yaml) but it is suggested you customise these values to suit your work load.
+
+
+The following table lists the configurable parameters of the MongoDB chart and their default values.
+
+
+| Parameter                                         | Description                                                                                   | Default                                   |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------------  | ----------------------------------------- |
+| `nameOverride`    								| the name override for the cahr                                                                | `""`                                      |
+| `fullnameOverride`		    					| the full name override for the chart                                                          | `""`                                      |
+| `mongo.image.repository`							| The image repository to pull mongodb image from												| `mongo`	    							|
+| `mongo.image.tag`									| The tag for the mongo image to be pulled														| `latest`									|
+| `mongo.image.pullPolicy`							| The pull policy for the chart to use while pulling mongodb containers							| `IfNotPresent`							|
+| `mongo.port`										| The port to expose for mongodb container					                               		| `27017`                                   |
+| `mongo.trials_db`									| The db in mongo to be used for trials storage				                        			| `model_db`                                |
+| `mongo.trials_collection`							| The collection in mongo to be used for trials				                        			| `jobs`                                    |
+| `mongo.service.type`								| Mongodb's service type (choose from ClusterIP / NodePort / LoadBalancer / ExternalName)		| `ClusterIP`                               |
+| `mongo.resources`									| Override to specify the resource requests and limits for the mongodb pods						| `{}`                                      |
+| `mongo.nodeSelector`								| Override to apply a node selector for mongodb deployment						            	| `{}`                                      |
+| `mongo.affinity`									| Override to define affinity for mongodb deployment						                	| `{}`                                      |
+| `mongo.tolerations`								| Override to define tolerations for mongodb deployment						                	| `{}`                                      |
+| `mongo.env`										| Env vars to provide to mongodb						                                    	| `{}`                                      |
+| `monitor.image.repository`						| The image repository to pull monitor image from					                			| `hipages/hyperkops-monitor`               |
+| `monitor.image.tag`								| The tag for the monitor image to be pulled							                       	| `latest`                                  |
+| `monitor.image.pullPolicy`						| The pull policy for the chart to use while pulling monitor containers							| `IfNotPresent`                            |
+| `monitor.resources`								| Override to specify the resource requests and limits for the monitor pods						| `{}`                                      |
+| `monitor.nodeSelector`							| Override to apply a node selector for monitor deployment						            	| `{}`                                      |
+| `monitor.affinity`								| Override to define affinity for monitor deployment						                	| `{}`                                      |
+| `monitor.tolerations`								| Override to define tolerations for monitor deployment						                	| `{}`                                      |
+| `monitor.env.TRIALS_TIMEOUT_INTERVAL`				| Env variable to set time out interval for the workload application							| `15`                                      |
+| `monitor.env.UPDATE_INTERVAL`						| Env variable to set update interval for the workload application			       				| `1`                                       |
+| `monitor.env.LOGLEVEL`							| Env variable to set log level for the monitor application				            			| `INFO`                                    |
+| `monitor.secrets`				    				| Settings to specify which secrets monitor will have access to		        					| `{}`                                      |
+| `worker.image.repository`							| The image repository to pull worker image from						                		| `hipages/hyperkops-worker`                |
+| `worker.image.tag`								| The tag for the worker image to be pulled							                        	| `latest`                                  |
+| `worker.image.pullPolicy`							| The pull policy for the chart to use while pulling worker containers							| `IfNotPresent`                            |
+| `worker.resources`								| Override to specify the resource requests and limits for the workload pods					| `{}`                                      |
+| `worker.nodeSelector`								| Override to apply a node selector for worker deployment						            	| `{}`                                      |
+| `worker.affinity`									| Override to define affinity for worker deployment					                    		| `{}`                                      |
+| `worker.tolerations`								| Override to define tolerations for worker deployment						                	| `{}`                                      |
+| `worker.env`										| Env vars to provide to the worker						                                    	| `{}`                                      |
+| `worker.hpa.enabled`								| Setting to enable Horizontal Pod autoscaler for worker deployment                           	| `false`                                   |
+| `worker.hpa.minReplicas`							| If the `worker.hpa.enabled` is true then this setting speciifies the minimum number of pods   | `1`                                       |
+| `worker.hpa.maxReplicas`						    | If the `worker.hpa.enabled` is true then this setting speciifies the maximum number of pods   | `50`                                      |
+| `worker.hpa.targetCPUUtilizationPercentage`	    | If the `worker.hpa.enabled` is true then this setting speciifies the taget CPU% for pods	    | `75`                                      |
+| `worker.hpa.targetMemoryUtilizationPercentage`    | If the `worker.hpa.enabled` is true then this setting speciifies the taget Memory% for pods   | `75`                                      |
+| `workload.image.repository`						| The image repository to pull workload image from		                						| `hipages/hyperkops-example`               |
+| `workload.image.tag`								| The tag for the workload image to be pulled				                       				| `latest`                                  |
+| `workload.image.pullPolicy`						| The pull policy for the chart to use while pulling workload containers						| `IfNotPresent`                            |
+| `workload.resources`								| Override to specify the resource requests and limits for the workload pods					| `{}`                                      |
+| `workload.nodeSelector`							| Override to apply a node selector for workload deployment					            		| `{}`                                      |
+| `workload.affinity`								| Override to define affinity for workload deployment							                | `{}`                                      |
+| `workload.tolerations`							| Override to define tolerations for workload deployment						               	| `{}`                                      |
+| `workload.env.LOGLEVEL`							| Env variable to set log level for the workload application							        | `INFO`                                    |
+| `workload.env.NUM_EVAL_STEPS`						| Env variable to set number of evaluation steps for the workload application					| `1000`                                    |
+| `workload.env.MULTIPLIER`							| Env variable to set multiplier for the workload application					        		| `2`                                       |
+| `workload.secrets.enabled`						| Specifies if the secrets are enabled for the chart			                   				| `false`                                   |
+| `workload.secrets.data.aws_access_key_id`	    	| Secrets to be specified as key value pair					                               		| `example`                                 |
+| `workload.secrets.data.aws_secret_access_key`	    | Secrets to be specified as key value pair				                               			| `example`                                 |
 

--- a/values.yaml
+++ b/values.yaml
@@ -1,7 +1,8 @@
 # Default values for hyperopt.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-common:
+nameOverride: ""
+fullnameOverride: ""
 
 mongo:
   image:
@@ -9,8 +10,6 @@ mongo:
     tag: latest
     pullPolicy: IfNotPresent
 
-  nameOverride: ""
-  fullnameOverride: ""
 
   port: 27017
 
@@ -47,9 +46,6 @@ monitor:
     tag: latest
     pullPolicy: IfNotPresent
 
-  nameOverride: ""
-  fullnameOverride: ""
-
   resources: {}
     # If you want to specify resources, uncomment the following
     # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
@@ -85,9 +81,6 @@ worker:
     tag: latest
     pullPolicy: IfNotPresent
 
-  nameOverride: ""
-  fullnameOverride: ""
-
   resources: {}
     # If you want to specify resources, uncomment the following
     # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
@@ -104,17 +97,7 @@ worker:
 
   affinity: {}
 
-  env:
-    AWS_DEFAULT_REGION : "ap-southeast-2"
-    AWS_ACCOUNT_ID: "987654321"
-    AWS_S3_BUCKET: "some-s3-bucket"
-    SCORING_METRIC: ""
-    LOGLEVEL: "DEBUG"
-    OPTIMISER_CONFIGURATION_PATH: ""
-    OPTIMISER_CONFIGURATION_LOCATION: "S3"
-    PYTHONUNBUFFERED: 0
-    NUM_EVAL_STEPS: 1
-    MULTIPLIER: 1
+  env: {}
 
   secrets:
     AWS_ACCESS_KEY_ID : aws_access_key_id
@@ -136,9 +119,6 @@ workload:
     repository: hipages/hyperkops-example
     tag: latest
     pullPolicy: IfNotPresent
-
-  nameOverride: ""
-  fullnameOverride: ""
 
   resources: {}
     # If you want to specify resources, uncomment the following
@@ -168,7 +148,7 @@ workload:
 
 # Place secret values here, which are then deployed as kube secrets
 secrets:
-  enabled: true
+  enabled: false
   data:
     aws_access_key_id: "example"
     aws_secret_access_key: "example"

--- a/values.yaml
+++ b/values.yaml
@@ -99,9 +99,10 @@ worker:
 
   env: {}
 
-  secrets:
-    AWS_ACCESS_KEY_ID : aws_access_key_id
-    AWS_SECRET_ACCESS_KEY : aws_secret_access_key
+  secrets: {}
+# Uncomment following lines to attach secrets as env vars
+#    AWS_ACCESS_KEY_ID : aws_access_key_id
+#    AWS_SECRET_ACCESS_KEY : aws_secret_access_key
 
   hpa:
     enabled: false


### PR DESCRIPTION
What changes are proposed in this pull request?
- Updated readme with more information on values
- removed some unused variables in values.yml
- Update to PR template, on instructions how to test

How was this change tested?
- [x] Manually deployed and tested with default values.yml
`kubectl config use-context docker-for-desktop`
`helm init`
`helm install .`
Output:
```
NAME:   historical-zorse
LAST DEPLOYED: Wed Jun 26 10:58:42 2019
NAMESPACE: default
STATUS: DEPLOYED

RESOURCES:
==> v1/Pod(related)
NAME                                                       READY  STATUS             RESTARTS  AGE
historical-zorse-chart-hyperopt-mongo-64cfd5cfbb-n2nb4     0/1    ContainerCreating  0         0s
historical-zorse-chart-hyperopt-monitor-6d464bb76f-4fnmz   0/1    ContainerCreating  0         0s
historical-zorse-chart-hyperopt-workers-6f74d4945f-9nn27   0/1    Pending            0         0s
historical-zorse-chart-hyperopt-workers-6f74d4945f-jl54h   0/1    ContainerCreating  0         0s
historical-zorse-chart-hyperopt-workload-675d95587d-bvc42  0/1    ContainerCreating  0         0s

==> v1/ServiceAccount

NAME                                     AGE
historical-zorse-chart-hyperopt-monitor  0s

==> v1/Role
historical-zorse-chart-hyperopt-monitor  0s

==> v1beta1/RoleBinding
historical-zorse-chart-hyperopt-monitor  0s

==> v1/Service
historical-zorse-chart-hyperopt-mongo  0s

==> v1beta2/Deployment
historical-zorse-chart-hyperopt-mongo     0s
historical-zorse-chart-hyperopt-monitor   0s
historical-zorse-chart-hyperopt-workers   0s
historical-zorse-chart-hyperopt-workload  0s


NOTES:
1. To connect mongo db using your local to deploy hyperopt job

export POD_NAME=$(kubectl get pods --namespace default -l "app.kubernetes.io/name=chart-hyperopt-mongo,app.kubernetes.io/instance=historical-zorse" -o jsonpath="{.items[0].metadata.name}")

kubectl port-forward $POD_NAME 27017:27017

You can then connect to mongo db at:
localhost:27017

2. you can connect to the mongo db on other deployments within the kubernetes environment using this service url:
"historical-zorse-chart-hyperopt-mongo.default.svc.cluster.local"
```

![image](https://user-images.githubusercontent.com/21052816/60143415-76617b00-9801-11e9-9ee1-f1b6a9b5b132.png)
