### PR TITLE
feat: Convert workload to be a job instead of a Deployment

### DIFF
--- a/templates/deployment_workload.yaml
+++ b/templates/deployment_workload.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.workload.enabled -}}
 {{- $secretname := include "hyperopt.fullname" . -}}
-apiVersion: apps/v1beta2
-kind: Deployment
+apiVersion: batch/v1
+kind: Job
 metadata:
   namespace: {{ .Release.Namespace }}
   name: {{ include "hyperopt.fullname" . }}-workload

--- a/templates/deployment_workload.yaml
+++ b/templates/deployment_workload.yaml
@@ -12,16 +12,13 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.workload.replicaCount }}
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: {{ include "hyperopt.name" . }}-workload
-      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       labels:
         app.kubernetes.io/name: {{ include "hyperopt.name" . }}-workload
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      restartPolicy: "Never"
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.workload.image.repository }}:{{ .Values.workload.image.tag }}"


### PR DESCRIPTION
What changes are proposed in this pull request?
(Please fill in changes proposed in this fix)
- Setup workload as a Job instead of Deployment

How was this change tested?
(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
- Tested on docker-for-desktop on mac
`kubectl config use-context docker-for-desktop`
`helm init`
`helm install .`
Output:
```
helm install .
NAME:   fancy-goose
LAST DEPLOYED: Mon Jul  1 10:26:23 2019
NAMESPACE: default
STATUS: DEPLOYED

RESOURCES:
==> v1beta2/Deployment
NAME                                AGE
fancy-goose-chart-hyperopt-mongo    0s
fancy-goose-chart-hyperopt-monitor  0s
fancy-goose-chart-hyperopt-workers  0s

==> v1/Job
fancy-goose-chart-hyperopt-workload  0s

==> v1/Pod(related)

NAME                                                 READY  STATUS             RESTARTS  AGE
fancy-goose-chart-hyperopt-mongo-798444d845-44tgk    0/1    ContainerCreating  0         0s
fancy-goose-chart-hyperopt-monitor-85dd8c868c-dqxsg  0/1    ContainerCreating  0         0s
fancy-goose-chart-hyperopt-workers-645dc69594-l47rr  0/1    ContainerCreating  0         0s
fancy-goose-chart-hyperopt-workers-645dc69594-tphbx  0/1    ContainerCreating  0         0s
fancy-goose-chart-hyperopt-workload-cdz4j            0/1    ContainerCreating  0         0s

==> v1/Secret

NAME                        AGE
fancy-goose-chart-hyperopt  0s

==> v1/ServiceAccount
fancy-goose-chart-hyperopt-monitor  0s

==> v1/Role
fancy-goose-chart-hyperopt-monitor  0s

==> v1beta1/RoleBinding
fancy-goose-chart-hyperopt-monitor  0s

==> v1/Service
fancy-goose-chart-hyperopt-mongo  0s


NOTES:
1. To connect mongo db using your local to deploy hyperopt job

export POD_NAME=$(kubectl get pods --namespace default -l "app.kubernetes.io/name=chart-hyperopt-mongo,app.kubernetes.io/instance=fancy-goose" -o jsonpath="{.items[0].metadata.name}")

kubectl port-forward $POD_NAME 27017:27017

You can then connect to mongo db at:
localhost:27017

2. you can connect to the mongo db on other deployments within the kubernetes environment using this service url:
"fancy-goose-chart-hyperopt-mongo.default.svc.cluster.local"

```

![image](https://user-images.githubusercontent.com/21052816/60404293-d9c91f80-9bea-11e9-8895-351cbd5f8ae0.png)
